### PR TITLE
Windows: use ffmpeg from Rtools when available

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,6 +22,7 @@ jobs:
           - {os: macos-14,        r: 'release'}
           - {os: windows-latest,  r: '4.1'}
           - {os: windows-latest,  r: '4.2'}
+          - {os: windows-latest,  r: '4.3'}
           - {os: windows-latest,  r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-24.04,   r: 'release'}

--- a/.github/workflows/RHEL-check.yml
+++ b/.github/workflows/RHEL-check.yml
@@ -1,0 +1,54 @@
+on:
+  push:
+  workflow_dispatch:
+
+name: rhel.yaml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+#  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  rhel:
+    runs-on: ubuntu-latest
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # cannot run the nodejs actions because RHEL7 cannot run node20
+          # - { os: rhel7, r: release, key: REDHAT_ACTIVATION_KEY_RHEL7 }
+          - { os: rhel8, r: release }
+          - { os: rhel9, r: release }
+    container:
+      image: ghcr.io/r-hub/containers/${{ matrix.config.os }}:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Register
+        run: |
+          subscription-manager register \
+            --org ${{ secrets.REDHAT_ORG }} \
+            --activationkey ${{ secrets.REDHAT_KEY }}
+        shell: bash
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: Unregister
+        if: always()
+        run: |
+          subscription-manager unregister || true
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: '"--no-manual"'
+        env:
+          NOT_CRAN: true
+          _R_CHECK_DOC_SIZES_: FALSE
+          LANG: en_US.UTF-8

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+0.9.4
+  - Windows: use ffmpeg from Rtools when available
+
 0.9.3
   - Fixes for ffmpeg 7.1
   - Cleanup configure script

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 0.9.4
   - Windows: use ffmpeg from Rtools when available
+  - Relax unit tests for libavfilter-free-devel on RedHat/Fedora
 
 0.9.3
   - Fixes for ffmpeg 7.1

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,7 +2,8 @@ PKG_CONFIG_NAME = libavfilter
 PKG_CONFIG ?= $(BINPREF)pkg-config
 PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_NAME))
 
-ifneq ($(PKG_LIBS),)
+# See https://bugs.r-project.org/show_bug.cgi?id=18835
+ifneq ($(findstring mp3lame,$(PKG_LIBS)),)
 $(info using ffmpeg from Rtools)
 PKG_CPPFLAGS := $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_NAME))
 else

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,3 +1,11 @@
+PKG_CONFIG_NAME = libavfilter
+PKG_CONFIG ?= $(BINPREF)pkg-config
+PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_NAME))
+
+ifneq ($(PKG_LIBS),)
+$(info using ffmpeg from Rtools)
+PKG_CPPFLAGS := $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_NAME))
+else
 RWINLIB = ../windows/ffmpeg
 PKG_CPPFLAGS = -I$(RWINLIB)/include -D__USE_MINGW_ANSI_STDIO=1 -DR_NO_REMAP -DSTRICT_R_HEADERS
 PKG_LIBS = -L$(RWINLIB)/lib${subst gcc,,$(COMPILED_BY)}$(R_ARCH) \
@@ -6,11 +14,14 @@ PKG_LIBS = -L$(RWINLIB)/lib${subst gcc,,$(COMPILED_BY)}$(R_ARCH) \
 	-lvorbis -lvorbisenc -logg -lvpx \
 	-lbz2 -lsecur32 -lws2_32 -liconv -lz -lmp3lame -lx264 \
 	-lxvidcore -pthread -lole32 -lm -luser32 -lbcrypt -lmfplat -lmfuuid -lstrmiids
+endif
 
-all: winlibs clean
+all: $(SHLIB)
+
+$(OBJECTS): $(RWINLIB)
+
+$(RWINLIB):
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
 
 clean:
 	rm -f $(SHLIB) $(OBJECTS)
-
-winlibs:
-	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"

--- a/tests/testthat/test-audio.R
+++ b/tests/testthat/test-audio.R
@@ -10,7 +10,7 @@ test_that("Audio can be converted to various formats", {
   input_info <- av_media_info(wonderland)
 
   # Convert mp3 to mkv (defaults to libvorbis audio)
-  expect_equal(av_audio_convert(wonderland, tmp_mkv, verbose = FALSE, sample_rate = 24000), tmp_mkv)
+  expect_equal(av_audio_convert(wonderland, tmp_mkv, verbose = FALSE, sample_rate = 16000), tmp_mkv)
   expect_true(file.exists(tmp_mkv))
   mkv_info <- av_media_info(tmp_mkv)
   expect_equal(input_info$duration, mkv_info$duration, tolerance = 0.1)

--- a/tests/testthat/test-audio.R
+++ b/tests/testthat/test-audio.R
@@ -10,7 +10,7 @@ test_that("Audio can be converted to various formats", {
   input_info <- av_media_info(wonderland)
 
   # Convert mp3 to mkv (defaults to libvorbis audio)
-  expect_equal(av_audio_convert(wonderland, tmp_mkv, verbose = FALSE), tmp_mkv)
+  expect_equal(av_audio_convert(wonderland, tmp_mkv, verbose = FALSE, sample_rate = 24000), tmp_mkv)
   expect_true(file.exists(tmp_mkv))
   mkv_info <- av_media_info(tmp_mkv)
   expect_equal(input_info$duration, mkv_info$duration, tolerance = 0.1)

--- a/tests/testthat/test-fft.R
+++ b/tests/testthat/test-fft.R
@@ -7,10 +7,11 @@ test_that("Audio FFT", {
   av_log_level(16) # muffle some warnings about ac3 vbr
   for(ext in extensions){
     filename <- paste0('wonderland.', ext)
-    av_audio_convert(wonderland, filename, verbose = FALSE)
+    # libopus on fedora does not do support input sample_rate 44100
+    av_audio_convert(wonderland, filename, verbose = FALSE, sample_rate = 48000)
     data <- read_audio_fft(filename, window = hanning(2048))
     expect_equal(dim(data)[1], 1024)
-    expect_equal(dim(data)[2], 2584, tol = 0.001)
+    expect_equal(dim(data)[2], 2813, tol = 0.001)
     unlink(filename)
   }
 })

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -26,7 +26,7 @@ test_that("Critical encoders", {
   expect_contains(encoders$name, 'libmp3lame')
   expect_contains(encoders$name, 'libvorbis')
   expect_contains(encoders$name, 'libxvid')
-  if(!grepl('redhat', R.version$platform)){
+  if(!grepl("(Fedora|Red Hat)", osVersion)){
     # libx264 is not supported on RHEL/Fedora libavfilter-free-devel but it is
     # in ffmpeg-devel from rpmfusion.
     expect_contains(encoders$name, 'libx264')

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -26,7 +26,9 @@ test_that("Critical encoders", {
   expect_contains(encoders$name, 'libmp3lame')
   expect_contains(encoders$name, 'libvorbis')
   expect_contains(encoders$name, 'libxvid')
-  skip_on_os('linux')
-  # libx264 is not supported on Fedora libavfilter-free-devel
-  expect_contains(encoders$name, 'libx264')
+  if(!grepl('redhat', R.version$platform)){
+    # libx264 is not supported on RHEL/Fedora libavfilter-free-devel but it is
+    # in ffmpeg-devel from rpmfusion.
+    expect_contains(encoders$name, 'libx264')
+  }
 })

--- a/tests/testthat/test-formats.R
+++ b/tests/testthat/test-formats.R
@@ -20,3 +20,13 @@ test_that("Listing formats", {
   expect_equal(names(decoders), c("type", "name", "description", "format"))
   expect_equal(names(filters), c("name", "description"))
 })
+
+test_that("Critical encoders", {
+  encoders <- av_encoders()
+  expect_contains(encoders$name, 'libmp3lame')
+  expect_contains(encoders$name, 'libvorbis')
+  expect_contains(encoders$name, 'libxvid')
+  skip_on_os('linux')
+  # libx264 is not supported on Fedora libavfilter-free-devel
+  expect_contains(encoders$name, 'libx264')
+})

--- a/tests/testthat/test-video.R
+++ b/tests/testthat/test-video.R
@@ -58,6 +58,11 @@ test_that("convert images into video formats", {
 test_that("audio sampling works", {
   for(ext in c("mkv", "mp4", "mov", "flv")){
     filename <- paste0("test.", ext)
+    if(grepl('redhat', R.version$platform)){
+      # libavfilter-free-devel only supports certain bitrates?
+      wonderland <- av_audio_convert(wonderland, tempfile(fileext = '.mka'), sample_rate = 48000, verbose = FALSE)
+    }
+    input_rate <- av_media_info(wonderland)$audio$sample_rate
     av::av_encode_video(png_files, filename, framerate = framerate, verbose = FALSE, audio = wonderland)
     expect_true(file.exists(filename))
     info <- av_media_info(filename)
@@ -70,7 +75,7 @@ test_that("audio sampling works", {
     expect_equal(info$video$framerate, framerate)
 
     expect_equal(info$audio$channels, 2)
-    expect_equal(info$audio$sample_rate, 44100)
+    expect_equal(info$audio$sample_rate, input_rate)
 
     # Audio stream may slightly alter the duration, 5% margin
     expect_equal(info$duration, n / framerate, tolerance = 0.05)
@@ -84,7 +89,7 @@ test_that("audio sampling works", {
     expect_equal(info$video$framerate, framerate)
 
     expect_equal(info$audio$channels, 2)
-    expect_equal(info$audio$sample_rate, 44100)
+    expect_equal(info$audio$sample_rate, input_rate)
 
     # Audio stream may slightly alter the duration, 5% margin
     expect_equal(info$duration, n / framerate, tolerance =  0.05)

--- a/tests/testthat/test-video.R
+++ b/tests/testthat/test-video.R
@@ -58,8 +58,8 @@ test_that("convert images into video formats", {
 test_that("audio sampling works", {
   for(ext in c("mkv", "mp4", "mov", "flv")){
     filename <- paste0("test.", ext)
-    if(grepl("(Fedora|Red Hat)", osVersion)){
-      # libavfilter-free-devel only supports certain bitrates?
+    if(ext == 'mkv' && grepl("(Fedora|Red Hat)", osVersion)){
+      # libavfilter-free-devel only supports certain audio bitrates
       wonderland <- av_audio_convert(wonderland, tempfile(fileext = '.mka'), sample_rate = 48000, verbose = FALSE)
     }
     input_rate <- av_media_info(wonderland)$audio$sample_rate

--- a/tests/testthat/test-video.R
+++ b/tests/testthat/test-video.R
@@ -58,7 +58,7 @@ test_that("convert images into video formats", {
 test_that("audio sampling works", {
   for(ext in c("mkv", "mp4", "mov", "flv")){
     filename <- paste0("test.", ext)
-    if(grepl('redhat', R.version$platform)){
+    if(grepl("(Fedora|Red Hat)", osVersion)){
       # libavfilter-free-devel only supports certain bitrates?
       wonderland <- av_audio_convert(wonderland, tempfile(fileext = '.mka'), sample_rate = 48000, verbose = FALSE)
     }


### PR DESCRIPTION
The ffmpeg build from rtools seems to have a bug that I have not seen anywhere else. No idea how to debug this.